### PR TITLE
Use count or estimatedDocumentCount based on the filters applied

### DIFF
--- a/src/resource.ts
+++ b/src/resource.ts
@@ -67,10 +67,10 @@ class Resource extends BaseResource {
     }
 
     async count(filters = null) {
-        if (Object.keys(convertFilter(filters)).length > 0) {
-            return this.MongooseModel.count(convertFilter(filters))
-        }
-        return this.MongooseModel.find(convertFilter(filters)).estimatedDocumentCount()
+       if (Object.keys(convertFilter(filters)).length > 0) {
+           return this.MongooseModel.count(convertFilter(filters))
+       }
+       return this.MongooseModel.find(convertFilter(filters)).estimatedDocumentCount()
     }
 
     async find(filters = {}, { limit = 20, offset = 0, sort = {} }: FindOptions) {

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -67,7 +67,10 @@ class Resource extends BaseResource {
     }
 
     async count(filters = null) {
-      return this.MongooseModel.find(convertFilter(filters)).estimatedDocumentCount()
+        if (Object.keys(convertFilter(filters)).length > 0) {
+            return this.MongooseModel.count(convertFilter(filters))
+        }
+        return this.MongooseModel.find(convertFilter(filters)).estimatedDocumentCount()
     }
 
     async find(filters = {}, { limit = 20, offset = 0, sort = {} }: FindOptions) {

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -67,10 +67,10 @@ class Resource extends BaseResource {
     }
 
     async count(filters = null) {
-       if (Object.keys(convertFilter(filters)).length > 0) {
-           return this.MongooseModel.count(convertFilter(filters))
-       }
-       return this.MongooseModel.find(convertFilter(filters)).estimatedDocumentCount()
+      if (Object.keys(convertFilter(filters)).length > 0) {
+          return this.MongooseModel.count(convertFilter(filters))
+      }
+      return this.MongooseModel.find(convertFilter(filters)).estimatedDocumentCount()
     }
 
     async find(filters = {}, { limit = 20, offset = 0, sort = {} }: FindOptions) {


### PR DESCRIPTION
There is an issue with this change applied here https://github.com/SoftwareBrothers/adminjs-mongoose/pull/75

`estimatedDocumentCount` always returns the total documents in the collection. It ignores the filers.  Ref: https://www.mongodb.com/docs/manual/reference/method/db.collection.estimatedDocumentCount/#behavior

The `count` method is still valid when you want to get the count of documents for a given filter.

The change made here is always returning the total documents in the collection no matter what filter is applied.

We need to add a condition to check if the filter exists and use the `estimatedDocumentCount` accordingly